### PR TITLE
*: fix command parameter for latest Prometheus

### DIFF
--- a/alertmanager/docker-compose.yml
+++ b/alertmanager/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus:/etc/prometheus:ro
   amtool:

--- a/blackbox-exporter/docker-compose.yml
+++ b/blackbox-exporter/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     depends_on:

--- a/cadvisor/docker-compose.yml
+++ b/cadvisor/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus:/etc/prometheus
     links:

--- a/federation/docker-compose.yml
+++ b/federation/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
   prometheus2:
@@ -13,7 +11,6 @@ services:
     ports:
     - 9091:9091
     command:
-    - --config.file=/etc/prometheus/prometheus.yml
     - --web.listen-address=0.0.0.0:9091
     volumes:
     - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro

--- a/file-sd/docker-compose.yml
+++ b/file-sd/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus:/etc/prometheus:ro
   myservice1: &myservice

--- a/go-app/docker-compose.yml
+++ b/go-app/docker-compose.yml
@@ -14,7 +14,5 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro

--- a/haproxy/docker-compose.yml
+++ b/haproxy/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     expose:
     - 9090
     command:
-    - --config.file=/etc/prometheus/prometheus.yml
     - --web.route-prefix=/prometheus
     - --web.external-url=http://example.com
     volumes:

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     ports:
     - 9090:9090
     command:
-    - --config.file=/etc/prometheus/prometheus.yml
     - --web.route-prefix=/
     - --web.external-url=http://example.com/prometheus
     volumes:

--- a/node-exporter/docker-compose.yml
+++ b/node-exporter/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     image: prom/prometheus:latest
     ports:
     - 9090:9090
-    command:
-    - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     depends_on:


### PR DESCRIPTION
The next `latest` image (eg v2.6.0) will break if started with `--config.file=/etc/prometheus/prometheus.yml` because the option is already included in the entrypoint. This PR should only be merged after v2.6.0 is out.

See https://github.com/prometheus/prometheus/pull/4796