### PR TITLE
Update image to version with more up-to-date certs

### DIFF
--- a/alertmanager/amtool/Dockerfile
+++ b/alertmanager/amtool/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.11beta1-alpine3.7
+FROM golang:1.18.3-alpine3.16
 
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache git \
-    && go get github.com/prometheus/alertmanager/cmd/amtool \
+    && go install github.com/prometheus/alertmanager/cmd/amtool@v0.24.0 \
     && apk del git


### PR DESCRIPTION
Fixes the issue caused by expired certs when building the image:

```
# cd .; git clone https://gopkg.in/yaml.v2 /go/src/gopkg.in/yaml.v2
Cloning into '/go/src/gopkg.in/yaml.v2'...
fatal: unable to access 'https://gopkg.in/yaml.v2/': SSL certificate problem: certificate has expired
package gopkg.in/yaml.v2: exit status 128

# cd .; git clone https://gopkg.in/alecthomas/kingpin.v2 /go/src/gopkg.in/alecthomas/kingpin.v2
Cloning into '/go/src/gopkg.in/alecthomas/kingpin.v2'...
fatal: unable to access 'https://gopkg.in/alecthomas/kingpin.v2/': SSL certificate problem: certificate has expired
package gopkg.in/alecthomas/kingpin.v2: exit status 128



package crypto/ed25519: unrecognized import path "crypto/ed25519" (import path does not begin with hos
tname)
```

Signed-off-by: Aibek <35672535+L1ghtman2k@users.noreply.github.com>